### PR TITLE
Add client support for skinned thermal stones

### DIFF
--- a/scripts/statusannouncer.lua
+++ b/scripts/statusannouncer.lua
@@ -112,7 +112,10 @@ function StatusAnnouncer:AnnounceItem(slot)
 		-- Try to get thermal stone temperature range to announce
 		local image_hash = item.replica.inventoryitem:GetImage()
 		local hash_lookup = {}
-		local skin_name = item:GetSkinName() or "heat_rock"
+		local skin_name = item.AnimState:GetSkinBuild()
+		if skin_name == "" then
+			skin_name = "heat_rock"
+		end
 		for i = 1,5 do
 			hash_lookup[hash(skin_name .. i .. ".tex")] = i
 		end


### PR DESCRIPTION
`item:GetSkinName()` only seems to work server-side, breaking the announcement of skinned thermals. This is just a quick patch I cooked up so it's a bit rudimentary, but it works.