### PR TITLE
Fix temperature announcement

### DIFF
--- a/scripts/statusannouncer.lua
+++ b/scripts/statusannouncer.lua
@@ -588,7 +588,7 @@ function StatusAnnouncer:AnnounceTemperature(pronoun)
 							TEMPERATURE = message,
 						})
 	if EXPLICIT then
-		message = string.format("(%d\176) %s", temp, message)
+		message = string.format("(%d\194\176) %s", temp, message)
 	end
 	local data = {
 		pronoun = pronoun,


### PR DESCRIPTION
DST's chat seems to discard messages with non-UTF-8 characters now, which completely breaks temperature announcements due to its use of a `b0` byte for `°`. Nothing appears at all when you try to announce your temperature.

This PR simply converts the character to its UTF-8 equivalent `c2b0` (`\194\176`) to restore its functionality.